### PR TITLE
feat: Support JSONMapPatch for array in subpath

### DIFF
--- a/body/json_map_patch.go
+++ b/body/json_map_patch.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"strings"
 
 	"github.com/google/martian/v3/log"
 	"github.com/google/martian/v3/parse"
@@ -71,18 +70,13 @@ func jsonMapPatch(original []byte, path string, patch *jsonpatch.Patch, options 
 		}
 	}
 
-	if path == "" || path == "/" {
-		modified, err = json.Marshal(array)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		var stringArray []string
-		for _, b := range array {
-			stringArray = append(stringArray, string(b))
-		}
+	modified, err = json.Marshal(array)
+	if err != nil {
+		return nil, err
+	}
 
-		p := fmt.Sprintf(`[{"op": "replace", "path": "%s", "value": [%s]}]`, path, strings.Join(stringArray, ","))
+	if path != "" && path != "/" {
+		p := fmt.Sprintf(`[{"op": "replace", "path": "%s", "value": [%s]}]`, path, modified)
 
 		patch, err := jsonpatch.DecodePatch([]byte(p))
 		if err != nil {
@@ -94,6 +88,7 @@ func jsonMapPatch(original []byte, path string, patch *jsonpatch.Patch, options 
 			return nil, err
 		}
 	}
+
 	return modified, nil
 }
 

--- a/body/json_map_patch.go
+++ b/body/json_map_patch.go
@@ -20,7 +20,7 @@ func init() {
 type jsonMapPatchModifierJSON struct {
 	Scope                    []parse.ModifierType `json:"scope"`
 	Patch                    jsonpatch.Patch      `json:"patch"`
-	Path										 string								`json:"path"`
+	Path                     string               `json:"path"`
 	SupportNegativeIndices   bool                 `json:"supportNegativeIndices"`
 	AccumulatedCopySizeLimit int64                `json:"accumulatedCopySizeLimit"`
 	SkipMissingPathOnRemove  bool                 `json:"skipMissingPathOnRemove"`
@@ -44,7 +44,7 @@ func NewJSONMapPatchModifier(patch *jsonpatch.Patch, options *jsonpatch.ApplyOpt
 	return &JSONMapPatchModifier{
 		patch:   patch,
 		options: options,
-		path:		 path,
+		path:    path,
 	}
 }
 

--- a/body/json_map_patch.go
+++ b/body/json_map_patch.go
@@ -76,7 +76,7 @@ func jsonMapPatch(original []byte, path string, patch *jsonpatch.Patch, options 
 	}
 
 	if path != "" && path != "/" {
-		p := fmt.Sprintf(`[{"op": "replace", "path": "%s", "value": [%s]}]`, path, modified)
+		p := fmt.Sprintf(`[{"op": "replace", "path": "%s", "value": %s}]`, path, modified)
 
 		patch, err := jsonpatch.DecodePatch([]byte(p))
 		if err != nil {

--- a/jsonpatch/patch.go
+++ b/jsonpatch/patch.go
@@ -871,7 +871,7 @@ func FindObject(doc []byte, path string) ([]byte, error) {
 	}
 
 	var pd container
-	if doc[0] == '[' {
+	if isArray(doc) {
 		pd = &partialArray{}
 	} else {
 		pd = &partialDoc{}

--- a/jsonpatch/patch.go
+++ b/jsonpatch/patch.go
@@ -866,7 +866,7 @@ func (p Patch) copy(doc *container, op Operation, accumulatedCopySize *int64, op
 
 // FindObject extracts the document at the requested path
 func FindObject(doc []byte, path string) ([]byte, error) {
-	if path == "" || path[len(path) - 1] != '/' {
+	if path == "" || path[len(path)-1] != '/' {
 		path = path + "/"
 	}
 

--- a/jsonpatch/patch.go
+++ b/jsonpatch/patch.go
@@ -864,6 +864,30 @@ func (p Patch) copy(doc *container, op Operation, accumulatedCopySize *int64, op
 	return nil
 }
 
+// FindObject extracts the document at the requested path
+func FindObject(doc []byte, path string) ([]byte, error) {
+	if path == "" || path[len(path) - 1] != '/' {
+		path = path + "/"
+	}
+
+	var pd container
+	if doc[0] == '[' {
+		pd = &partialArray{}
+	} else {
+		pd = &partialDoc{}
+	}
+
+	err := json.Unmarshal(doc, pd)
+
+	if err != nil {
+		return nil, err
+	}
+
+	pd, _ = findObject(&pd, path, nil)
+
+	return json.Marshal(pd)
+}
+
 // Equal indicates if 2 JSON documents have the same structural equality.
 func Equal(a, b []byte) bool {
 	la := newLazyNode(newRawMessage(a))


### PR DESCRIPTION
Added a small feature to allow `JSONMapPatch` to be used on sub path in JSON body.

Example config:
```yaml
modifiers: |
  - method.Filter:
      method: GET
      modifier:
        fifo.Group:
            - bff.URLFilter:
                scope: [request]
                modifier:
                  fifo.Group:
                    modifiers:
                      - bff.MethodModifier:
                          method: POST
                      - body.Modifier:
                          contentType: 'application/json'
                          body: e30K # {}
                      - body.JSONPatch:
                          patch:
                            - {op: add, path: /sub, value: []}
                            - {op: add, path: /sub/-, value: {"foo": "bar"}}
                            - {op: add, path: /sub/-, value: {"foo": "baz"}}
                      - body.JSONMapPatch:
                          path: /sub
                          patch:
                            - {op: move, from: /foo, path: "/FOO"}
                            - {op: add, path: /abc, value: "def"}
```

Output:
```json
{
  "data": "{\"sub\":[{\"FOO\":\"bar\",\"abc\":\"def\"},{\"FOO\":\"baz\",\"abc\":\"def\"}]}", 
  "json": {
    "sub": [
      {
        "FOO": "bar", 
        "abc": "def"
      }, 
      {
        "FOO": "baz", 
        "abc": "def"
      }
    ]
  }
}
```