### PR TITLE
feat: Add status filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,24 @@ url.Filter:
       value: "true"
 ```
 
+#### Status
+
+The `status.Filter` executes its contained modifier if the response status code
+matches the specified status code.
+
+Example configuration that sets the `Mod-Run` header to true on all requests
+that returns status code of `200`.
+
+```yaml
+status.Filter:
+  scope: [response]
+  statusCode: 200
+  modifier:
+    header.Modifier:
+      name: Mod-Run
+      value: "true"
+```
+
 ### Verifiers
 
 Verifier check network traffic against defined expectations. Failed

--- a/bffstatus/status_filter.go
+++ b/bffstatus/status_filter.go
@@ -30,7 +30,7 @@ func init() {
 	parse.Register("status.Filter", filterFromJSON)
 }
 
-// Filter runs modifiers iff the request URL matches all of the segments in url.
+// Filter runs modifiers if the response status code matches the specified status code.
 type Filter struct {
 	*filter.Filter
 }
@@ -42,10 +42,6 @@ type filterJSON struct {
 	Scope        []parse.ModifierType `json:"scope"`
 }
 
-// filterFromJSON takes a JSON message as a byte slice and returns a
-// parse.Result that contains a URLFilter and a bitmask that represents the
-// type of modifier.
-//
 // Example JSON configuration message:
 // {
 //   "statusCode": 401,
@@ -85,7 +81,7 @@ func filterFromJSON(b []byte) (*parse.Result, error) {
 }
 
 // NewFilter constructs a filter that applies the modifer when the
-// request URL matches all of the provided URL segments.
+// response status code matches the statusCode.
 func NewFilter(statusCode int) *Filter {
 	log.Debugf("status.NewFilter: %d", statusCode)
 
@@ -97,25 +93,25 @@ func NewFilter(statusCode int) *Filter {
 }
 
 
-// Matcher is a conditional evaluator of request urls to be used in
+// Matcher is a conditional evaluator of response statud code to be used in
 // filters that take conditionals.
 type Matcher struct {
 	statusCode int
 }
 
-// NewMatcher builds a new url matcher.
+// NewMatcher builds a new status code matcher.
 func NewMatcher(statusCode int) *Matcher {
 	return &Matcher{
 		statusCode: statusCode,
 	}
 }
 
-// MatchRequest always returns false since request will not have status code
+// MatchRequest always returns false since request will not have any status code.
 func (m *Matcher) MatchRequest(req *http.Request) bool {
 	return false
 }
 
-// MatchResponse retuns true if m.StatusCode matches res.StatusCode
+// MatchResponse retuns true if m.StatusCode matches res.StatusCode.
 func (m *Matcher) MatchResponse(res *http.Response) bool {
 	matched := m.matches(res.StatusCode)
 
@@ -126,7 +122,6 @@ func (m *Matcher) MatchResponse(res *http.Response) bool {
 	return matched
 }
 
-// matches forces all non-empty URL segments to match or it returns false.
 func (m *Matcher) matches(statusCode int) bool {
 	return statusCode == m.statusCode
 }

--- a/bffstatus/status_filter.go
+++ b/bffstatus/status_filter.go
@@ -92,7 +92,6 @@ func NewFilter(statusCode int) *Filter {
 	return &Filter{f}
 }
 
-
 // Matcher is a conditional evaluator of response statud code to be used in
 // filters that take conditionals.
 type Matcher struct {

--- a/bffstatus/status_filter.go
+++ b/bffstatus/status_filter.go
@@ -1,0 +1,132 @@
+// Copyright 2015 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bffstatus
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/google/martian/v3"
+	"github.com/google/martian/v3/filter"
+	"github.com/google/martian/v3/log"
+	"github.com/google/martian/v3/parse"
+)
+
+var noop = martian.Noop("status.Filter")
+
+func init() {
+	parse.Register("status.Filter", filterFromJSON)
+}
+
+// Filter runs modifiers iff the request URL matches all of the segments in url.
+type Filter struct {
+	*filter.Filter
+}
+
+type filterJSON struct {
+	StatusCode   int                  `json:"statusCode"`
+	Modifier     json.RawMessage      `json:"modifier"`
+	ElseModifier json.RawMessage      `json:"else"`
+	Scope        []parse.ModifierType `json:"scope"`
+}
+
+// filterFromJSON takes a JSON message as a byte slice and returns a
+// parse.Result that contains a URLFilter and a bitmask that represents the
+// type of modifier.
+//
+// Example JSON configuration message:
+// {
+//   "statusCode": 401,
+//   "scope": ["request", "response"],
+//   "modifier": { ... }
+//   "else": { ... }
+// }
+func filterFromJSON(b []byte) (*parse.Result, error) {
+	msg := &filterJSON{}
+	if err := json.Unmarshal(b, msg); err != nil {
+		return nil, err
+	}
+
+	filter := NewFilter(msg.StatusCode)
+
+	m, err := parse.FromJSON(msg.Modifier)
+	if err != nil {
+		return nil, err
+	}
+
+	filter.RequestWhenTrue(m.RequestModifier())
+	filter.ResponseWhenTrue(m.ResponseModifier())
+
+	if len(msg.ElseModifier) > 0 {
+		em, err := parse.FromJSON(msg.ElseModifier)
+		if err != nil {
+			return nil, err
+		}
+
+		if em != nil {
+			filter.RequestWhenFalse(em.RequestModifier())
+			filter.ResponseWhenFalse(em.ResponseModifier())
+		}
+	}
+
+	return parse.NewResult(filter, msg.Scope)
+}
+
+// NewFilter constructs a filter that applies the modifer when the
+// request URL matches all of the provided URL segments.
+func NewFilter(statusCode int) *Filter {
+	log.Debugf("status.NewFilter: %d", statusCode)
+
+	m := NewMatcher(statusCode)
+	f := filter.New()
+	f.SetRequestCondition(m)
+	f.SetResponseCondition(m)
+	return &Filter{f}
+}
+
+
+// Matcher is a conditional evaluator of request urls to be used in
+// filters that take conditionals.
+type Matcher struct {
+	statusCode int
+}
+
+// NewMatcher builds a new url matcher.
+func NewMatcher(statusCode int) *Matcher {
+	return &Matcher{
+		statusCode: statusCode,
+	}
+}
+
+// MatchRequest always returns false since request will not have status code
+func (m *Matcher) MatchRequest(req *http.Request) bool {
+	return false
+}
+
+// MatchResponse retuns true if m.StatusCode matches res.StatusCode
+func (m *Matcher) MatchResponse(res *http.Response) bool {
+	matched := m.matches(res.StatusCode)
+
+	if matched {
+		log.Debugf("status.Matcher.MatchResponse: matched: %s", m.statusCode)
+	}
+
+	return matched
+}
+
+// matches forces all non-empty URL segments to match or it returns false.
+func (m *Matcher) matches(statusCode int) bool {
+	return statusCode == m.statusCode
+}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -39,6 +39,7 @@ import (
 	_ "github.com/google/martian/v3/status"
 	_ "github.com/imranismail/bff/bffmethod"
 	_ "github.com/imranismail/bff/bffurl"
+	_ "github.com/imranismail/bff/bffstatus"
 	_ "github.com/imranismail/bff/body"
 )
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -38,8 +38,8 @@ import (
 	_ "github.com/google/martian/v3/static"
 	_ "github.com/google/martian/v3/status"
 	_ "github.com/imranismail/bff/bffmethod"
-	_ "github.com/imranismail/bff/bffurl"
 	_ "github.com/imranismail/bff/bffstatus"
+	_ "github.com/imranismail/bff/bffurl"
 	_ "github.com/imranismail/bff/body"
 )
 


### PR DESCRIPTION
This PR add the status filter to filter response based on the returned status code

Example config
```yaml
status.Filter:
  scope: [response]
  statusCode: 200
  modifier:
    header.Modifier:
      name: Mod-Run
      value: "true"
```