### PR TITLE
feat: Support query string modifier

### DIFF
--- a/bffquerystring/query_string_modifier.go
+++ b/bffquerystring/query_string_modifier.go
@@ -1,0 +1,128 @@
+// Copyright 2015 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package bffquerystring contains a modifier to rewrite query strings in a request.
+package bffquerystring
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"regexp"
+
+	"github.com/google/martian/v3"
+	"github.com/google/martian/v3/parse"
+)
+
+func init() {
+	parse.Register("bff.QuerystringModifier", modifierFromJSON)
+}
+
+type modifier struct {
+	op, key, value string
+}
+
+type modifierJSON struct {
+	Key   string               `json:"name"`
+	Value string               `json:"value"`
+	Op    string               `json:"op"`
+	Scope []parse.ModifierType `json:"scope"`
+}
+
+
+func replaceParams(value string, req *http.Request) string {
+		re := regexp.MustCompile(`^:([0-9A-Za-z_]+)$`)
+		matches := re.FindStringSubmatch(value)
+		if len(matches) == 2 {
+			param := "bffurl.ParamName." + matches[1]
+			ctx := martian.NewContext(req)
+			if val, ok := ctx.Get(param); ok {
+				value = val.(string)
+			}
+		}
+		return value
+}
+
+// ModifyRequest modifies the query string of the request with the given key and value.
+func (m *modifier) ModifyRequest(req *http.Request) error {
+	query := req.URL.Query()
+	v := query.Get(m.key)
+
+	switch m.op {
+	case "add":
+		if v == "" {
+			value := replaceParams(m.value, req)
+			query.Set(m.key, value)
+		}
+
+	case "replace":
+		if v != "" {
+			value := replaceParams(m.value, req)
+			query.Set(m.key, value)
+		}
+
+	case "delete":
+		if v != "" {
+			query.Del(m.key)
+		}
+
+	case "copy":
+		if v != "" {
+			query.Set(m.value, v)
+		}
+
+	case "move":
+		if v != "" {
+			query.Set(m.value, v)
+			query.Del(m.key)
+		}
+
+	default:
+		return errors.New(fmt.Sprintf("bffquerystring.Modifier: Unknown operation '%s'", m.op))
+	}
+	req.URL.RawQuery = query.Encode()
+
+	return nil
+}
+
+// NewModifier returns a request modifier that will set the query string
+// at key with the given value. If the query string key already exists all
+// values will be overwritten.
+func NewModifier(op, key, value string) martian.RequestModifier {
+	return &modifier{
+		op:    op,
+		key:   key,
+		value: value,
+	}
+}
+
+// modifierFromJSON takes a JSON message as a byte slice and returns
+// a bffquerystring.modifier and an error.
+//
+// Example JSON:
+// {
+//  "name": "param",
+//  "value": "true",
+//  "scope": ["request", "response"]
+// }
+func modifierFromJSON(b []byte) (*parse.Result, error) {
+	msg := &modifierJSON{}
+
+	if err := json.Unmarshal(b, msg); err != nil {
+		return nil, err
+	}
+
+	return parse.NewResult(NewModifier(msg.Op, msg.Key, msg.Value), msg.Scope)
+}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -38,6 +38,7 @@ import (
 	_ "github.com/google/martian/v3/static"
 	_ "github.com/google/martian/v3/status"
 	_ "github.com/imranismail/bff/bffmethod"
+	_ "github.com/imranismail/bff/bffquerystring"
 	_ "github.com/imranismail/bff/bffstatus"
 	_ "github.com/imranismail/bff/bffurl"
 	_ "github.com/imranismail/bff/body"


### PR DESCRIPTION
Enable patching query string, taking inspiration from jsonpatch.
```yaml
# original: ?foo1=bar
# modified: ?foo2=bar
- bff.QuerystringModifier:
    op: move
    name: foo1
    value: foo2

# original: ?foo1=bar
# modified: ?foo1=bar&foo2=bar
- bff.QuerystringModifier:
    op: copy
    name: foo1
    value: foo2

# original: ?foo1=bar1
# modified: ?foo1=bar1&foo2=bar2
- bff.QuerystringModifier:
    op: add
    name: foo2
    value: bar2

# original: ?foo=bar
# modified: ?foo=baz
- bff.QuerystringModifier:
    op: replace
    name: foo
    value: baz

# original: ?foo1=bar1&foo2=bar2
# modified: ?foo1=bar1
- bff.QuerystringModifier:
    op: remove
    name: foo2
```